### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/src/classes/terminal.class.js
+++ b/src/classes/terminal.class.js
@@ -464,7 +464,11 @@ class Terminal {
                     this.ondisconnected(code, reason);
                 });
                 ws.on("message", msg => {
-                    this.tty.write(msg);
+                    if (typeof msg === "string" && /^[\x20-\x7E]*$/.test(msg)) { // Allow only printable ASCII characters
+                        this.tty.write(msg);
+                    } else {
+                        console.warn("Received invalid or potentially unsafe message:", msg);
+                    }
                 });
                 this.tty.onData(data => {
                     this._nextTickUpdateTtyCWD = true;


### PR DESCRIPTION
Potential fix for [https://github.com/matu6968/edex-ui/security/code-scanning/1](https://github.com/matu6968/edex-ui/security/code-scanning/1)

To fix the issue, we need to ensure that the `msg` variable is validated or sanitized before being passed to `this.tty.write()`. This involves:
1. Adding a validation step to ensure that `msg` contains only expected and safe data. For example, if `msg` is expected to be a string of printable characters, we can validate it against a whitelist of allowed characters.
2. If `msg` contains unexpected or unsafe data, it should be rejected or sanitized before further processing.

The fix will involve modifying the code around line 467 to include a validation step for `msg`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
