### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/file-icons-generator.js
+++ b/file-icons-generator.js
@@ -11,6 +11,7 @@
 
 
 const fs = require("fs");
+const escapeStringRegexp = require("escape-string-regexp");
 const path = require("path");
 const CSON = require("cson-parser");
 
@@ -206,7 +207,8 @@ Object.keys(atomConfig.directoryIcons).forEach(key => {
                     }
                 });
             } else if (typeof config.alias === "string") {
-                config.alias = new RegExp(config.alias.replace(/\./g, "\\.")+"$", "i"); // lgtm [js/incomplete-sanitization]
+                const escapedAlias = escapeStringRegexp(config.alias);
+                config.alias = new RegExp(escapedAlias + "$", "i");
                 fileIconsMatchScript += `    if (${config.alias}.test(filename)) { return "${config.icon}"; }\n`;
             }
         }
@@ -229,12 +231,14 @@ Object.keys(atomConfig.fileIcons).forEach(key => {
             if (Array.isArray(config.alias)) {
                 config.alias.forEach(aliasItem => {
                     if (typeof aliasItem === "string") {
-                        let aliasRegex = new RegExp(aliasItem.replace(/\./g, "\\.")+"$", "i"); // lgtm [js/incomplete-sanitization]
+                        const escapedAliasItem = escapeStringRegexp(aliasItem);
+                        let aliasRegex = new RegExp(escapedAliasItem + "$", "i");
                         fileIconsMatchScript += `    if (${aliasRegex}.test(filename)) { return "${config.icon}"; }\n`;
                     }
                 });
             } else if (typeof config.alias === "string") {
-                config.alias = new RegExp(config.alias.replace(/\./g, "\\.")+"$", "i"); // lgtm [js/incomplete-sanitization]
+                const escapedAlias = escapeStringRegexp(config.alias);
+                config.alias = new RegExp(escapedAlias + "$", "i");
                 fileIconsMatchScript += `    if (${config.alias}.test(filename)) { return "${config.icon}"; }\n`;
             }
         }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "mime-types": "^3.0.1",
     "node-abi": "4.11.0",
     "node-json-minify": "^3.0.0",
-    "terser": "^5.43.1"
+    "terser": "^5.43.1",
+    "escape-string-regexp": "^5.0.0"
   },
   "optionalDependencies": {
     "cson-parser": "^4.0.9"


### PR DESCRIPTION
Potential fix for [https://github.com/matu6968/edex-ui/security/code-scanning/11](https://github.com/matu6968/edex-ui/security/code-scanning/11)

To fix the issue, we need to ensure that backslashes in the input string are properly escaped before constructing the regular expression. This can be achieved by adding a step to replace backslashes (`\`) with double backslashes (`\\`) in the input string. Additionally, we should use a well-tested sanitization library like `escape-string-regexp` to handle escaping reliably, as it is designed specifically for this purpose.

The changes will involve:
1. Importing the `escape-string-regexp` library.
2. Replacing the manual `replace` calls with `escapeStringRegexp` to escape both dots and backslashes correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
